### PR TITLE
fix: rbtrees start in the middle

### DIFF
--- a/widget/src/rbTree.tsx
+++ b/widget/src/rbTree.tsx
@@ -42,7 +42,7 @@ function treeToData(tree: RBTreeVars): RBNodeDatum {
 }
 
 function renderForeignObjectNode({ nodeDatum }: CustomNodeElementProps, pos: DocumentPosition,
-    foreignObjectProps: React.SVGProps<SVGForeignObjectElement>): JSX.Element {
+  foreignObjectProps: React.SVGProps<SVGForeignObjectElement>): JSX.Element {
   const nodeDatum_ = nodeDatum as RBNodeDatum
   return (
     <g>
@@ -54,19 +54,34 @@ function renderForeignObjectNode({ nodeDatum }: CustomNodeElementProps, pos: Doc
   )
 }
 
-export default function({pos, tree}: {pos: DocumentPosition, tree: RBTreeVars}) {
+export default function ({ pos, tree }: { pos: DocumentPosition, tree: RBTreeVars }) {
   const nodeSize = { x: 40, y: 80 }
   const foreignObjectProps = { width: nodeSize.x, height: nodeSize.y, y: -10, x: -4 }
+  const r = React.useRef<HTMLDivElement>(null)
+  const [t, setT] = React.useState<any | null>(null)
+  React.useLayoutEffect(() => {
+    const elt = r.current
+    if (elt == null) { return }
+    if (t != null) { return }
+    const b = elt.getBoundingClientRect()
+    if (!b.width || !b.height) { return }
+    console.log("b: ", b)
+    setT({ x: b.width / 2, y: 20 })
+
+  })
   return (
     <div
       style={{
         height: '200px',
         display: 'inline-flex',
-        minWidth: '50px'
+        minWidth: '50px',
+        border: '1px solid rgba(100, 100, 100, 0.2)',
       }}
+      ref={r}
     >
       <Tree
         data={treeToData(tree)}
+        translate={t ?? { x: 0, y: 0 }}
         nodeSize={nodeSize}
         renderCustomNodeElement={rd3tProps =>
           renderForeignObjectNode(rd3tProps, pos, foreignObjectProps)}


### PR DESCRIPTION
Now in the rbtree demo, when you select an rbtree the default layout is more sensible.
I also added a border so it's more obvious where the viewbox is.