### PR TITLE
chore: bump to nightly-2023-08-19

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-07-15
+leanprover/lean4:nightly-2023-08-19


### PR DESCRIPTION
I wouldn't usually suggest an necessary bump, but `nightly-2023-08-19` is now a tentative release candidate for the first official release of Lean 4, and it would be nice to try everything out on it explicitly.